### PR TITLE
avoid NullPointerException if group parent is null.

### DIFF
--- a/src/impl/java/org/wyona/security/impl/yarep/YarepUser.java
+++ b/src/impl/java/org/wyona/security/impl/yarep/YarepUser.java
@@ -699,7 +699,7 @@ public class YarepUser extends YarepItem implements User {
         log.debug("Get parent group IDs for particular group: " + groupID);
 
         GroupManager gm = getGroupManager();
-        if (gm != null) {
+        if (gm != null && gm.getGroup(groupID)!=null) {
             Group[] parentGroups = gm.getGroup(groupID).getParents();
             if (parentGroups != null) {
                 for (int i = 0; i < parentGroups.length; i++) {


### PR DESCRIPTION
Hi Michael,
this is a very simple patch for the YarepUser.java class.
I sometimes had the case where it threw a `NullPointerException`, so this patch is to avoid this.
